### PR TITLE
Remove useless line

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,6 @@ function parseFile(filename, options) {
     'jade_variables(locals);' +
     compiler.compile() +
     '}';
-  Function('', js);
   var ast = uglify.parse(js, {filename: filename});
 
   ast.figure_out_scope();


### PR DESCRIPTION
I do not understand why this line would be necessary (except if it is simply to throw an error because `js` cannot be converted to a function)
