### PR TITLE
Add mixin support (except mixin.attrs & mixin.merge)

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,6 +74,7 @@ function parseFile(filename, options) {
     'function jade_join_classes(val) {' +
     'return Array.isArray(val) ? val.map(jade_join_classes).filter(function (val) { return val != null && val !== ""; }).join(" ") : val;' +
     '};' +
+    'var jade_mixins = {};' +
     'var jade_interp;' +
     'jade_variables(locals);' +
     compiler.compile() +

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -15,12 +15,30 @@ function toConstant(str) {
 module.exports = Compiler;
 function Compiler(node) {
   this.node = node;
+  this.mixins = {};
+  this.dynamicMixins = false;
 }
 
 Compiler.prototype.compile = function(){
   this.buf = [];
   this.buf.push('return React.DOM.div({}, (function () {var tags = [];');
   this.visit(this.node);
+
+  if (!this.dynamicMixins) {
+    // if there are no dynamic mixins we can remove any un-used mixins
+    var mixinNames = Object.keys(this.mixins);
+    for (var i = 0; i < mixinNames.length; i++) {
+      var mixin = this.mixins[mixinNames[i]];
+      if (!mixin.used) {
+        for (var x = 0; x < mixin.instances.length; x++) {
+          for (var y = mixin.instances[x].start; y < mixin.instances[x].end; y++) {
+            this.buf[y] = '';
+          }
+        }
+      }
+    }
+  }
+  
   this.buf.push('return tags;}()));');
   return this.buf.join('\n');
 };
@@ -87,6 +105,79 @@ Compiler.prototype.visitLiteral = function (literal) {
     this.buf.push('tags.push(' + JSON.stringify(literal.str) + ')');
   }
 };
+Compiler.prototype.visitMixinBlock = function(block){
+    this.buf.push('block && (tags = tags.concat(block()));');
+};
+
+
+Compiler.prototype.visitMixin = function(mixin) {
+    var name = 'jade_mixins[';
+    var args = mixin.args || '';
+    var block = mixin.block;
+    var attrs = mixin.attrs;
+    var attrsBlocks = mixin.attributeBlocks;
+    var pp = this.pp;
+    var dynamic = mixin.name[0]==='#';
+    var key = mixin.name;
+    if (dynamic) this.dynamicMixins = true;
+    name += (dynamic ? mixin.name.substr(2,mixin.name.length-3):'"'+mixin.name+'"')+']';
+
+    this.mixins[key] = this.mixins[key] || {used: false, instances: []};
+    if (mixin.call) {
+      this.mixins[key].used = true;
+      //if (pp) this.buf.push("jade_indent.push('" + Array(this.indents + 1).join('  ') + "');")
+      if (block || attrs.length || attrsBlocks.length) {
+
+        this.buf.push('tags = tags.concat(' + name + '.call({');
+
+        if (block) {
+          this.buf.push('block: function(){');
+          this.buf.push('var tags = [];');
+          // Render block with no indents, dynamically added when rendered
+          this.visit(mixin.block);
+          this.buf.push('return tags;');
+
+          if (attrs.length || attrsBlocks.length) {
+            this.buf.push('},');
+          } else {
+            this.buf.push('}');
+          }
+        }
+
+        if (attrsBlocks.length) {
+          if (attrs.length) {
+            var val = this.attrs(attrs);
+            attrsBlocks.unshift(val);
+          }
+          this.buf.push('attributes: jade.merge([' + attrsBlocks.join(',') + '])');
+        } else if (attrs.length) {
+          var val = this.attrs(attrs);
+          this.buf.push('attributes: ' + val);
+        }
+
+        if (args) {
+          this.buf.push('}, ' + args + '));');
+        } else {
+          this.buf.push('}));');
+        }
+
+      } else {
+        this.buf.push('tags = tags.concat(' + name + '(' + args + '));');
+        this.buf.push(name + '(' + args + ');');
+      }
+    } else {
+      var mixin_start = this.buf.length;
+      this.buf.push(name + ' = function(' + args + '){');
+      this.buf.push('var block = (this && this.block), attributes = (this && this.attributes) || {};');
+      this.buf.push('var tags = [];');
+      this.visit(block);
+      this.buf.push('return tags;');
+      this.buf.push('};');
+      var mixin_end = this.buf.length;
+      this.mixins[key].instances.push({start: mixin_start, end: mixin_end});
+    }
+};
+ 
 Compiler.prototype.visitTag = function (tag) {
   this.buf.push('tags.push(React.DOM.' + tag.name + '(');
 

--- a/test/index.js
+++ b/test/index.js
@@ -22,7 +22,6 @@ try {
 fs.readdirSync(inputDir).filter(function (name) {
   return /\.jade$/.test(name) &&
     !/doctype/.test(name) &&
-    !/mixin/.test(name) &&
     !/filter/.test(name) &&
     !/case/.test(name) &&
     'xml.jade' !== name &&
@@ -43,6 +42,8 @@ fs.readdirSync(inputDir).filter(function (name) {
     'code.iteration.jade' !== name &&
     'code.escape.jade' !== name &&
     'blockquote.jade' !== name &&
+    'mixin.attrs.jade' !== name &&
+    'mixin.merge.jade' !== name &&
     'attrs.js.jade' !== name &&
     'attrs.jade' !== name &&
     'attrs.interpolation.jade' !== name &&


### PR DESCRIPTION
I tried to keep as close as possible to the jade implementation ;
- removed all the indentation
- kept the dynamicMixins stuff
- added the `tags` array logic / concat for mixin calls & mixin blocks

all tests are passing except for the mixin.attrs & mixin.merge tests. I did not look into these since they are more related to the attrs handling and I am not sure about the status of this in react-jade ; maybe you will see things clearer than me on those).

Tell me if it looks ok to you !
