### PR TITLE
Template literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,41 @@ var html = React.renderComponentToString(template({local: 'values'}));
 fs.writeFileSync(__dirname + '/template.html', html);
 ```
 
+### ES6
+
+If you are using ES6 server side, or the browserify transform client side (even without any other ES6 support), you can use Tagged Literals to embed your jade code directly within your JavaScript components:
+
+```js
+var TodoList = React.createClass({
+  render: jade`
+ul
+  each item in this.props.items
+`
+});
+var TodoApp = React.createClass({
+  getInitialState: function() {
+    return {items: [], text: ''};
+  },
+  onChange: function(e) {
+    this.setState({text: e.target.value});
+  },
+  handleSubmit: function(e) {
+    e.preventDefault();
+    var nextItems = this.state.items.concat([this.state.text]);
+    var nextText = '';
+    this.setState({items: nextItems, text: nextText});
+  },
+  render: jade`
+h3 TODO
+TodoList(items=this.state.items)
+form(onSubmit=this.handleSubmit)
+  input(onChange=this.onChange value=this.state.text)
+  button= 'Add #' + (this.state.items.length + 1)
+`.locals({TodoList: TodoList})
+});
+React.renderComponent(TodoApp(), mountNode);
+```
+
 ## API
 
 ```js

--- a/lib/acorn-transform.js
+++ b/lib/acorn-transform.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var acorn = require('acorn');
+var walk = require('acorn/util/walk');
+
+module.exports = transform;
+function transform(src, walker) {
+  var ast = acorn.parse(src, {ecmaVersion: 6});
+  src = src.split('');
+
+  function getSource(node) {
+    return src.slice(node.start, node.end).join('');
+  }
+  function setSource(node, str) {
+    for (var i = node.start; i < node.end; i++) {
+      src[i] = '';
+    }
+    src[node.start] = str;
+  }
+  module.exports.getSource = getSource;
+  module.exports.setSource = setSource;
+
+  walk.ancestor(ast, walker);
+
+  return src.join('');
+}
+
+module.exports.stringify = function(str) {
+  return JSON.stringify(str)
+             .replace(/\u2028/g, '\\u2028')
+             .replace(/\u2029/g, '\\u2029');
+};

--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
   "description": "Compile Jade to React JavaScript",
   "keywords": [],
   "dependencies": {
-    "resolve": "~0.7.0",
-    "uglify-js": "~2.4.13",
-    "jade": "~1.3.1",
-    "static-module": "0.0.7",
+    "acorn": "^0.9.0",
     "constantinople": "~2.0.1",
-    "ent": "~2.0.0"
+    "ent": "~2.0.0",
+    "jade": "~1.3.1",
+    "resolve": "~0.7.0",
+    "static-module": "0.0.7",
+    "uglify-js": "~2.4.13"
   },
   "devDependencies": {
     "gethub": "~1.0.2",

--- a/test/index.js
+++ b/test/index.js
@@ -189,7 +189,14 @@ test('bonus-features/component-composition.jade', function () {
      fs.writeFileSync(outputDir + '/' + name + '.actual.dom', domToString(actual) + '\n');
      assert(domToString(expected) === domToString(actual), 'Expected output dom to match expected dom (see /test/output/' + name + '.actual.dom and /test/output/' + name + '.expected.dom for details.');
   }
+});
 
-
-
+test('bonus-features/browserify', function (done) {
+  fs.createReadStream(require.resolve('./test-client.js'))
+    .pipe(jade(require.resolve('./test-client.js')))
+    .pipe(fs.createWriteStream(__dirname + '/output/test-client.js'))
+    .on('close', function () {
+      require('./output/test-client.js');
+      done();
+    });
 });

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var assert = require('assert');
+var React = require('react');
+var jade = require('react-jade');
+
+var test = /^\<div id\=\"container\".*\>Some Text\<\/div\>$/;
+
+var templateA = jade`
+#container Some Text
+`;
+assert(test.test(React.renderComponentToString(templateA())));
+
+var templateB = jade.compile('#container Some Text');
+assert(test.test(React.renderComponentToString(templateB())));


### PR DESCRIPTION
This lets you inline your jade, making it easier to build components:

``` js

var TodoList = React.createClass({
  render: jade`
ul
  each item in this.props.items
`
});
var TodoApp = React.createClass({
  getInitialState: function() {
    return {items: [], text: ''};
  },
  onChange: function(e) {
    this.setState({text: e.target.value});
  },
  handleSubmit: function(e) {
    e.preventDefault();
    var nextItems = this.state.items.concat([this.state.text]);
    var nextText = '';
    this.setState({items: nextItems, text: nextText});
  },
  render: jade`
h3 TODO
TodoList(items=this.state.items)
form(onSubmit=this.handleSubmit)
  input(onChange=this.onChange value=this.state.text)
  button= 'Add #' + (this.state.items.length + 1)
`.locals({TodoList: TodoList})
});
React.renderComponent(TodoApp(), mountNode);
```

Unlike JSX though, this is using fully standards compliant JavaScript, so it will work server side without compilation (in an environment that supports ES6) and will be well supported by tooling (although it looks like GitHub's syntax highlighter hasn't quite caught up yet)
