### PR TITLE
upgrade React dependency to React 0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ var jade = require('react-jade');
 
 var template = jade.compileFile(__dirname + '/template.jade');
 
-React.renderComponent(template({local: 'values'}), document.getElementById('container'));
+React.render(template({local: 'values'}), document.getElementById('container'));
 ```
 
 ```
@@ -47,13 +47,13 @@ Then on your html page:
 <script src="http://fb.me/react-0.10.0.js"></script>
 <script src="template.js"></script>
 <script>
-  React.renderComponent(template({local: 'values'}), document.getElementById('container'));
+  React.render(template({local: 'values'}), document.getElementById('container'));
 </script>
 ```
 
 ### Server Side
 
-You can also use react-jade to render templates on the server side via `React.renderComponentToString`.  This is especially useful for building isomorphic applications (i.e. applications that run the same on the server side and client side).
+You can also use react-jade to render templates on the server side via `React.renderToString`.  This is especially useful for building isomorphic applications (i.e. applications that run the same on the server side and client side).
 
 ```js
 var fs = require('fs');
@@ -62,7 +62,7 @@ var jade = require('react-jade');
 
 var template = jade.compileFile(__dirname + '/template.jade');
 
-var html = React.renderComponentToString(template({local: 'values'}));
+var html = React.renderToString(template({local: 'values'}));
 fs.writeFileSync(__dirname + '/template.html', html);
 ```
 
@@ -98,7 +98,7 @@ form(onSubmit=this.handleSubmit)
   button= 'Add #' + (this.state.items.length + 1)
 `.locals({TodoList: TodoList})
 });
-React.renderComponent(TodoApp(), mountNode);
+React.render(TodoApp(), mountNode);
 ```
 
 ## API
@@ -152,7 +152,7 @@ var jade = require('react-jade');
 
 var template = jade.compileFile(__dirname + '/template.jade').locals({title: 'React Jade'});
 
-React.renderComponent(template({local: 'values'}), document.getElementById('container'));
+React.render(template({local: 'values'}), document.getElementById('container'));
 ```
 
 ## Differences from jade
@@ -168,7 +168,7 @@ button(onClick=clicked) Click Me!
 ```
 ```js
 var fn = jade.compileFile('template.jade');
-React.renderComponent(fn({clicked: function () { alert('clicked'); }), container);
+React.render(fn({clicked: function () { alert('clicked'); }), container);
 ```
 
 Often, you may want to partially apply a function, e.g.

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -40,8 +40,8 @@ Compiler.prototype.compile = function(){
     }
   }
   this.buf.push('if (tags.length === 1) { return tags.pop() };');
-  this.buf.push('tags.unshift({});');
-  this.buf.push('return React.DOM.div.apply(React.DOM, tags);');
+  this.buf.push('tags.unshift("div", null);');
+  this.buf.push('return React.createElement.apply(React, tags);');
   this.buf.push('}.call(this));');
   return this.buf.join('\n');
 };
@@ -58,7 +58,7 @@ Compiler.prototype.visitCode = function (code) {
     throw new Error('Not Implemented');
   }
   if (code.buffer && !code.escape) {
-    this.buf.push('tags.push(React.DOM.div({dangerouslySetInnerHTML:{__html: ' + code.val + '}}))');
+    this.buf.push('tags.push(React.createElement("div", {dangerouslySetInnerHTML:{__html: ' + code.val + '}}))');
   } else if (code.buffer) {
     this.buf.push('tags.push(' + code.val + ')');
   } else {
@@ -204,11 +204,11 @@ Compiler.prototype.visitMixin = function(mixin) {
 };
  
 Compiler.prototype.visitTag = function (tag) {
-  if (tag.name in React.DOM) {
-    this.buf.push('tags.push(React.DOM.' + tag.name + '.apply(React.DOM, ');
-  } else {
-    this.buf.push('tags.push(' + tag.name + '.apply(null, ');
+  var name = tag.name;
+  if (/^[a-z]/.test(tag.name)) {
+    name = '"' + name + '"';
   }
+  this.buf.push('tags.push(React.createElement.apply(React, ['+name);
   
 
   if (tag.name === 'textarea' && tag.code && tag.code.buffer && tag.code.escape) {
@@ -219,7 +219,7 @@ Compiler.prototype.visitTag = function (tag) {
     tag.code = null;
   }
 
-  this.buf.push('[' + getAttributes(tag.attrs) + ']');
+  this.buf.push(',' + getAttributes(tag.attrs) + ']');
   if (tag.code || (tag.block && tag.block.nodes.length)) {
     this.buf.push('.concat(function () { var tags = [];');
     if (tag.code) this.visitCode(tag.code);

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "htmlparser2": "~3.7.1",
     "istanbul": "^0.3.2",
     "marked": "~0.3.2",
-    "react": "~0.11.0",
+    "react": "~0.12.0",
     "rimraf": "~2.2.8",
     "testit": "~1.2.0"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -156,7 +156,7 @@ fs.readdirSync(bonusDir).filter(function (name) {
   test(name, function () {
     var fn = jade.compileFile(bonusDir + '/' + name + '.jade');
     var c = React.createClass({ render: fn });
-    var html = React.renderComponentToStaticMarkup(c({ title: 'Jade', list: ['a', 'b', 'c']}));
+    var html = React.renderToStaticMarkup(React.createElement(c, { title: 'Jade', list: ['a', 'b', 'c']}));
 
     var actual = htmlparser.parseDOM(html);
     var expected = htmlparser.parseDOM(fs.readFileSync(bonusDir + '/' + name + '.html', 'utf8'));
@@ -180,7 +180,7 @@ test('bonus-features/component-composition.jade', function () {
     render: render2
   });
 
-  var html = React.renderComponentToStaticMarkup(c({ title: 'Jade', items: [ 'a', 'b', 'c' ]}));
+  var html = React.renderToStaticMarkup(React.createElement(c, { title: 'Jade', items: [ 'a', 'b', 'c' ]}));
 
   var actual = htmlparser.parseDOM(html);
   var expected = htmlparser.parseDOM(fs.readFileSync(bonusDir + '/' + name + '.html', 'utf8'));

--- a/test/mock-dom.js
+++ b/test/mock-dom.js
@@ -4,11 +4,17 @@ var React = require('react');
 
 var tags = Object.keys(React.DOM);
 var originalValues = tags.map(function (tag) { return React.DOM[tag]; });
+var originalCreateElement = React.createElement;
 
 exports.mock = mock;
 function mock() {
   for (var i = 0; i < tags.length; i++) {
     React.DOM[tags[i]] = mockFor(tags[i]);
+  }
+  React.createElement = function() {
+    var args = Array.prototype.slice.call(arguments, 0);
+    var tag = args.shift();
+    return mockFor(tag).apply(null, args);
   }
   function mockFor(name) {
     return function (attribs) {
@@ -45,4 +51,5 @@ function reset() {
   for (var i = 0; i < tags.length; i++) {
     React.DOM[tags[i]] = originalValues[i];
   }
+  React.createElement = originalCreateElement;
 }

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -9,7 +9,7 @@ var test = /^\<div id\=\"container\".*\>Some Text\<\/div\>$/;
 var templateA = jade`
 #container Some Text
 `;
-assert(test.test(React.renderComponentToString(templateA())));
+assert(test.test(React.renderToString(templateA())));
 
 var templateB = jade.compile('#container Some Text');
-assert(test.test(React.renderComponentToString(templateB())));
+assert(test.test(React.renderToString(templateB())));


### PR DESCRIPTION
cf http://facebook.github.io/react/blog/2014/10/28/react-v0.12.html

1/ renderComponent\* becomes render*
2/ React.DOM.\* should no longer be used. According to http://facebook.github.io/react/blog/2014/10/16/react-v0.12-rc1.html, "All JSX tags that start with a lower-case letter or contain a dash are treated as HTML"
3/ a component can no longer be used as a function. It needs React.createElement - https://gist.github.com/sebmarkbage/ae327f2eda03bf165261

All tests are passing. I had to modify the mock ; the modification took the "fast" way as I decided to leave the React.DOM mock at this stage.
