### PR TITLE
Import props into locals

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -27,6 +27,7 @@ function parse(str, options) {
   var compiler = new Compiler(tokens);
 
   var js = 'var fn = function (locals) {' +
+    'locals = locals || {};' +
     jade_join_classes + ';' +
     jade_fix_style + ';' +
     'var jade_mixins = {};' +

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -87,7 +87,7 @@ function parse(str, options) {
   assert(/jade_variables\(locals\)/.test(js));
 
   js = js.replace(/\n? *jade_variables\(locals\);?/, globals.map(function (g) {
-    return '  var ' + g + ' = ' + JSON.stringify(g) + ' in locals ? locals.' + g + ' : jade_globals_' + g + ';';
+    return '  var ' + g + ' = ' + JSON.stringify(g) + ' in locals ? locals.' + g + ' : ( this.props && ' + JSON.stringify(g) + ' in this.props ) ? this.props.' + g + ' : jade_globals_' + g + ';';
   }).join('\n'));
   return globals.map(function (g) {
     return 'var jade_globals_' + g + ' = typeof ' + g + ' === "undefined" ? undefined : ' + g + ';\n';


### PR DESCRIPTION
This is a feature suggestion.

I suggest that `locals` should be switched to `this.props` in react-jade as they represent the same concept and may better fit into React. The current changes only add `this.props` when resolving values of local variables.

I was trying to make two Jade templates and use one inside of another (summary of my code, not tested):

``` jade
h1 Parent template with title
    = title
ChildTemplate( title= title )
p Parent end
```

``` jade
h2 Child template with title
    = title
p Child end
```

``` html
<div id="container"></div>
<script src="http://fb.me/react-0.12.2.js"></script>
<script src="parentTemplate.js"></script>
<script src="childTemplate.js"></script>
<script>
React.render(
    parentTemplate({
        title: "Hello world!",
        ChildTemplate: React.createClass({ render: childTemplate }),
    }),
    document.getElementById( "container" );
);
```

The problem in my eyes was that `title` variable could be accessed directly in _parentTemplate_, but had to be accessed as `this.props.title` in _childTemplate_.

I would also suggest creating a mechanism for calling `React.createClass({ render: yourTemplateFunction })` automagicly: either when creating local variables or adding it as a property of a compiled template instance.
